### PR TITLE
Aggregate first attempt distribution data for answer distribution table

### DIFF
--- a/edx/analytics/tasks/answer_dist.py
+++ b/edx/analytics/tasks/answer_dist.py
@@ -34,8 +34,8 @@ UNKNOWN_ANSWER_VALUE = ''
 UNMAPPED_ANSWER_VALUE = ''
 
 
-class LastProblemCheckEventMixin(object):
-    """Identifies last problem_check event for a user on a problem in a course, given raw event log input."""
+class ProblemCheckEventMixin(object):
+    """Identifies first and last problem_check events for a user on a problem in a course, given raw event log input."""
 
     def mapper(self, line):
         """
@@ -66,7 +66,7 @@ class LastProblemCheckEventMixin(object):
 
     def reducer(self, _key, values):
         """
-        Calculate a list of answers from the final response of a user to a problem in a course.
+        Calculate a list of answers from the first and last responses of a user to a problem in a course.
 
         Args:
             key:  (problem_id, username)
@@ -104,18 +104,25 @@ class LastProblemCheckEventMixin(object):
         if not values:
             return
 
+        # Get the first entry.
+        _timestamp, first_event = values[0]
+
+        for answer in self._generate_answers(first_event, is_first_event=True):
+            yield answer
+
         # Get the last entry.
         _timestamp, most_recent_event = values[-1]
 
-        for answer in self._generate_answers(most_recent_event):
+        for answer in self._generate_answers(most_recent_event, is_first_event=False):
             yield answer
 
-    def _generate_answers(self, event_string):
+    def _generate_answers(self, event_string, is_first_event):
         """
         Generates a list of answers given a problem_check event.
 
         Args:
             event_string:  a json-encoded string version of an event's data.
+            is_first_event: a boolean that is True for a user's first response to a question, False otherwise
 
         Returns:
             list of answer data tuples.
@@ -137,6 +144,7 @@ class LastProblemCheckEventMixin(object):
             # not found in the submission:
             submission['problem_id'] = problem_id
             submission['problem_display_name'] = problem_display_name
+            submission['is_first_event'] = is_first_event
 
             # Add the timestamp so that all responses can be sorted in order.
             # We want to use the "latest" values for some fields.
@@ -340,11 +348,15 @@ class AnswerDistributionPerCourseMixin(object):
                     'Problem Display Name': problem_display_name or '',
                     'Question': question,
                     'Correct Answer': '1' if answer.get('correct') else '0',
-                    'Count': 0,
+                    'First Response Count': 0,
+                    'Last Response Count': 0,
                 }
 
             # For most cases, just increment a counter:
-            answer_dist[answer_grouping_key]['Count'] += 1
+            if answer.get('is_first_event', False):
+                answer_dist[answer_grouping_key]['First Response Count'] += 1
+            else:
+                answer_dist[answer_grouping_key]['Last Response Count'] += 1
 
         # Finally dispatch the answers, providing the course_id as a
         # key so that the answers belonging to a course will be
@@ -361,7 +373,8 @@ class AnswerDistributionPerCourseMixin(object):
             'ModuleID',
             'PartID',
             'Correct Answer',
-            'Count',
+            'First Response Count',
+            'Last Response Count',
             'ValueID',
             'AnswerValue',
             'Variant',
@@ -589,14 +602,14 @@ class BaseAnswerDistributionTask(MapReduceJobTask):
         return [html5lib, six]
 
 
-class LastProblemCheckEvent(LastProblemCheckEventMixin, BaseAnswerDistributionTask):
-    """Identifies last problem_check event for a user on a problem in a course, given raw event log input."""
+class ProblemCheckEvent(ProblemCheckEventMixin, BaseAnswerDistributionTask):
+    """Identifies problem_check event for a user on a problem in a course, given raw event log input."""
 
     def requires(self):
         return PathSetTask(self.src, self.include, self.manifest)
 
     def output(self):
-        output_name = u'last_problem_check_events_{name}/'.format(name=self.name)
+        output_name = u'problem_check_events_{name}/'.format(name=self.name)
         return get_target_from_url(url_path_join(self.dest, output_name))
 
 
@@ -617,7 +630,7 @@ class AnswerDistributionPerCourse(AnswerDistributionPerCourseMixin, BaseAnswerDi
 
     def requires(self):
         results = {
-            'events': LastProblemCheckEvent(
+            'events': ProblemCheckEvent(
                 mapreduce_engine=self.mapreduce_engine,
                 input_format=self.base_input_format,
                 lib_jar=self.lib_jar,
@@ -764,7 +777,8 @@ class InsertToMysqlAnswerDistributionTableBase(MysqlInsertTask):
                     row_dict['ModuleID'],
                     row_dict['PartID'],
                     row_dict['Correct Answer'],
-                    row_dict['Count'],
+                    row_dict['First Response Count'],
+                    row_dict['Last Response Count'],
                     row_dict['ValueID'] if row_dict['ValueID'] else None,
                     row_dict['AnswerValue'] if row_dict['AnswerValue'] else None,
                     try_str_to_float(row_dict['AnswerValue']),
@@ -785,7 +799,8 @@ class InsertToMysqlAnswerDistributionTableBase(MysqlInsertTask):
             ('module_id', 'VARCHAR(255) NOT NULL'),
             ('part_id', 'VARCHAR(255) NOT NULL'),
             ('correct', 'TINYINT(1) NOT NULL'),
-            ('count', 'INT(11) NOT NULL'),
+            ('first_response_count', 'INT(11) NOT NULL'),
+            ('last_response_count', 'INT(11) NOT NULL'),
             ('value_id', 'VARCHAR(255)'),
             ('answer_value_text', 'LONGTEXT'),
             ('answer_value_numeric', 'DOUBLE'),
@@ -926,6 +941,9 @@ def get_problem_check_event(line):
     problem_id = problem_data.get('problem_id')
     if problem_id is None:
         log.error("encountered explicit problem_check event with bogus problem_id: %s", event)
+        return None
+
+    if len(event.get('event', {}).get('answers', [])) == 0:
         return None
 
     problem_data_json = json.dumps(problem_data)


### PR DESCRIPTION
This adds the ability for the pipeline to aggregate users' first responses to questions to complement the existing data on their last responses.  There is an associated PR against edx/edx-analytics-pipeline with a longer discussion of design decisions and commentary.  The only differences are that for this PR, all uses of 'final' have been replaced with 'last' for clarity and that submissions with totally empty answer values are omitted from the counting.  This is a partial fix for the mismatched counts bug which David discovered.

This should be useful for developing against over the next week.  It would also be good to have it reviewed before spring quarter starts.  @dcadams @stvstnfrd @Stanford-Online/openedx-analytics @ataki
