### PR TITLE
Add course video analytics for analytics pipeline.

### DIFF
--- a/edx/analytics/tasks/course_video.py
+++ b/edx/analytics/tasks/course_video.py
@@ -1,0 +1,668 @@
+"""
+Luigi tasks for extracting course video information from tracking logs.
+"""
+import math
+import html5lib
+import json
+from operator import itemgetter
+from datetime import datetime
+
+import luigi
+import luigi.hdfs
+import luigi.s3
+
+from edx.analytics.tasks.mapreduce import MapReduceJobTask, MapReduceJobTaskMixin
+from edx.analytics.tasks.pathutil import PathSetTask
+from edx.analytics.tasks.url import get_target_from_url, url_path_join
+from edx.analytics.tasks.mysql_load import MysqlInsertTask, MysqlInsertTaskMixin
+import edx.analytics.tasks.util.eventlog as eventlog
+import edx.analytics.tasks.util.opaque_key_util as opaque_key_util
+
+import logging
+log = logging.getLogger(__name__)
+
+################################
+# Task Map-Reduce definitions
+################################
+
+EVENT_ACTION_MAPPING = {
+    'play_video': 'P',
+    'seek_video': 'E',
+    'stop_video': 'S',
+    'load_video': 'L',
+}
+
+SEEK_INTERVAL_IN_SEC = 10
+
+DATE_FMT = "%m-%d-%Y"
+
+def round_to_nearest(number, roundto):
+    """
+    Rounds number to nearest multiple of roundto and returns the
+    integer multiple of roundto.
+
+    Returns None if an error occurs
+    """
+    result = round(number / roundto) * roundto
+    try:
+        return int(result)
+    except:
+        return None
+
+
+def round_datetime_to_nearest_day(datetime_obj):
+    """
+    Rounds date down to nearest day,
+    and reports the date in a common
+    dd-mm-yyyy format.
+
+    Returns None on error
+    """
+    if type(datetime_obj) != datetime:
+        return None
+    else:
+        return datetime_obj.replace(hour=0, minute=0, second=0, microsecond=0).strftime(DATE_FMT)
+
+
+class CourseVideoEventMixin(object):
+    """
+    Base class for extracting video play information from event.logs.
+    The most basic implementation counts, for each video in each
+    course, the number of unique users and number of times the
+    video has been played.
+    """
+
+    def mapper(self, line):
+        """ Docstring """
+        parsed_tuple_or_none = self.parse_log_line(line)
+        if parsed_tuple_or_none is not None:
+            yield parsed_tuple_or_none
+
+    def reducer(self, key, values):
+        """
+        Base classes should implement this method
+        """
+        raise NotImplementedError
+
+    def parse_log_line(self, line):
+        """ Docstring """
+        try:
+            event = json.loads(line)
+        except ValueError:
+            log.error("Error parsing log line %s" % line)
+            return None
+
+        key = self.get_mapper_key(event)
+        value = self.get_mapper_value(event)
+        if key is None or value is None:
+            return None
+        return key, value
+
+    def get_mapper_key(self, event):
+        """
+        Outputs the key used by the mapper and reducer.
+        Base classes should implement this method.
+        """
+        raise NotImplementedError
+
+    def get_mapper_value(self, event):
+        """
+        Outputs the other tuple used by the mapper.
+        Reducer is sent an iterable of these tuples.
+        Base classes should implement this method.
+        """
+        raise NotImplementedError
+
+
+class CourseVideoSummaryMixin(CourseVideoEventMixin):
+    """ Docstring """
+
+    def reducer(self, key, value_gen):
+        """ Docstring """
+        values = [x for x in value_gen]
+        usernames = map(itemgetter(0), values)
+        unique_users = len(set(usernames))
+        total_activity = len(values)
+        output = (unique_users, total_activity)
+        yield key, output
+
+    def get_mapper_key(self, event):
+        """ Docstring """
+        if type(event) != dict:
+            return None
+
+        video_data = eventlog.get_event_data(event)
+        if video_data is None:
+            return None
+
+        context = event.get('context')
+        if type(context) != dict:
+            return None
+
+        course_id = context.get('course_id')
+        if course_id is None or not opaque_key_util.is_valid_course_id(course_id):
+            return None
+
+        video_id = video_data.get('id')
+        if video_id is None:
+            return None
+
+        timestamp = eventlog.get_event_time(event)
+        if timestamp is None:
+            return None
+
+        date = round_datetime_to_nearest_day(timestamp)
+        return (course_id, video_id, date)
+
+    def get_mapper_value(self, event):
+        """ Docstring """
+        if type(event) != dict:
+            return None
+
+        username = event.get('username')
+        if not username:
+            return None
+
+        action = event.get('event_type')
+        if action != "play_video":
+            return None
+
+        encoded_action = EVENT_ACTION_MAPPING.get(action)
+        return (username, encoded_action)
+
+
+class CourseVideoSeekTimesMixin(CourseVideoEventMixin):
+    """
+    For each video in a course, counts the number of seeks
+    at each interval of the video.
+    """
+
+    def reducer(self, key, values):
+        """ Docstring """
+        num_seeks = 0
+        users = set()
+        for value in values:
+            num_seeks += 1
+            users.add(value[0])
+        num_users = len(users)
+        output = (num_seeks, num_users)
+        yield key, output
+
+    def get_mapper_key(self, event):
+        """ Docstring """
+        if type(event) != dict:
+            return None
+
+        action = event.get('event_type')
+
+        if action != 'seek_video':
+            return None
+
+        video_data = eventlog.get_event_data(event)
+        if video_data is None:
+            return None
+
+        timestamp = eventlog.get_event_time(event)
+        if timestamp is None:
+            return None
+
+        context = event.get('context')
+        if type(context) != dict:
+            return None
+
+        course_id = context.get('course_id')
+        if course_id is None:
+            return None
+
+        video_id = video_data.get('id')
+        if video_id is None:
+            return None
+
+        target = int(video_data.get('new_time'))
+        if not (timestamp and course_id and video_id and target):
+            return None
+
+        if math.isnan(target) or not opaque_key_util.is_valid_course_id(course_id):
+            return None
+
+        date = round_datetime_to_nearest_day(timestamp)
+
+        seek_interval = round_to_nearest(target, SEEK_INTERVAL_IN_SEC)
+        if not date and not seek_interval:
+            return None
+
+        return (course_id, video_id, date, seek_interval)
+
+    def get_mapper_value(self, event):
+        """ Docstring """
+        if type(event) != dict:
+            return None
+
+        username = event.get('username')
+        if not username:
+            return None
+
+        timestamp = eventlog.get_event_time(event)
+        if not timestamp:
+            return None
+
+        return (username, timestamp)
+
+
+class UserVideoSummaryMixin(CourseVideoEventMixin):
+    """ Docstring """
+
+    def reducer(self, key, value_gen):
+        """ Docstring """
+        values = [value for value in value_gen]
+        total_activity = len(values)
+        video_ids = map(itemgetter(0), values)
+        unique_videos_watched = len(set(video_ids))
+
+        total_time_spent = self.get_total_time_spent(values)
+
+        output = (total_activity, unique_videos_watched, total_time_spent)
+        yield key, output
+
+    def get_mapper_key(self, event):
+        """ Docstring """
+        if type(event) != dict:
+            return None
+
+        context = event.get('context')
+        if type(context) != dict:
+            return None
+
+        course_id = context.get('course_id')
+        username = event.get('username')
+        timestamp = eventlog.get_event_time(event)
+        date = round_datetime_to_nearest_day(timestamp)
+        if not (course_id and username and timestamp and date):
+            return None
+
+        if not opaque_key_util.is_valid_course_id(course_id):
+            return None
+
+        return (course_id, username, date)
+
+    def get_mapper_value(self, event):
+        """ Docstring """
+        if type(event) != dict:
+            return None
+
+        action = event.get('event_type')
+        if action not in EVENT_ACTION_MAPPING:
+            return None
+
+        video_data = eventlog.get_event_data(event)
+        if video_data is None:
+            return None
+
+        encoded_action = EVENT_ACTION_MAPPING.get(action)
+        video_id = video_data.get("id")
+        timestamp = eventlog.get_event_time(event)
+        session_id = event.get('session')
+        if not (video_id and timestamp and session_id):
+            return None
+
+        return (video_id, encoded_action, session_id, timestamp)
+
+    def generate_video_session_attr_filter(self, video_id, session_id):
+        """ Docstring """
+        def filter_fn(value):
+            """ Docstring """
+            return value[0] == video_id and value[2] == session_id
+        return filter_fn
+
+    def get_video_session_attrs(self, value):
+        """ Docstring """
+        return (value[0], value[2])
+
+    def get_timestamp_attr(self):
+        """ Gets timestamp attribute from map value """
+        return itemgetter(3)
+
+    def get_total_time_spent(self, values):
+        """ Docstring """
+        total_time = 0
+        video_session_pairs = set(map(self.get_video_session_attrs, values))
+
+        # calculate total time spent on videos
+        for video_id, session_id in video_session_pairs:
+            session_events = filter(
+                    self.generate_video_session_attr_filter(video_id, session_id),
+                    values)
+
+            timestamp_getter = self.get_timestamp_attr()
+            if len(session_events) != 0:
+                earliest_event = min(session_events, key=timestamp_getter)
+                latest_event = max(session_events, key=timestamp_getter)
+                started_watching = timestamp_getter(earliest_event)
+                stopped_watching = timestamp_getter(latest_event)
+
+                total_seconds = (stopped_watching - started_watching).total_seconds()
+                total_time += max(total_seconds, 0)
+
+        return int(total_time)
+
+##################################
+# Task requires/output definitions
+##################################
+
+class CourseVideoDownstreamMixin(object):
+    """
+    Base class for adding Luigi parameters to course video mapreduce tasks.
+
+    Parameters:
+        name: a unique identifier to distinguish one run from another.  It is used in
+            the construction of output filenames, so each run will have distinct outputs.
+        src:  a URL to the root location of input tracking log files.
+        dest:  a URL to the root location to write output file(s).
+        include:  a list of patterns to be used to match input files, relative to `src` URL.
+            The default value is ['*'].
+        manifest: a URL to a file location that can store the complete set of input files.
+    """
+    name = luigi.Parameter()
+    src = luigi.Parameter(is_list=True)
+    dest = luigi.Parameter()
+    include = luigi.Parameter(is_list=True, default=('*',))
+    # A manifest file is required by hadoop if there are too many
+    # input paths. It hits an operating system limit on the number of
+    # arguments passed to the mapper process on the task nodes.
+    manifest = luigi.Parameter(default=None)
+
+
+# pylint: disable=E1101
+class BaseCourseVideoMapReduceTask(MapReduceJobTask):
+    """Base class for course video mapreduce tasks."""
+    def requires(self):
+        return PathSetTask(self.src, self.include, self.manifest)
+
+    def extra_modules(self):
+        import six
+        return [html5lib, six]
+
+
+class CourseVideoSummaryTask(
+    CourseVideoDownstreamMixin,
+    CourseVideoSummaryMixin,
+    BaseCourseVideoMapReduceTask
+):
+    """
+    Basic mapreduce task. Calculates total activity and unique users for each
+    video / user combo
+    """
+    def output(self):
+        output_name = u'cv_video_summary_{name}/'.format(name=self.name)
+        return get_target_from_url(url_path_join(self.dest, output_name))
+
+
+class CourseVideoSeekTimesTask(
+    CourseVideoDownstreamMixin,
+    CourseVideoSeekTimesMixin,
+    BaseCourseVideoMapReduceTask
+):
+    """
+    Basic mapreduce task. Calculates total activity and unique users for each
+    video / user combo
+    """
+    def output(self):
+        output_name = u'cv_seek_times_{name}/'.format(name=self.name)
+        return get_target_from_url(url_path_join(self.dest, output_name))
+
+
+class UserVideoSummaryTask(
+    CourseVideoDownstreamMixin,
+    UserVideoSummaryMixin,
+    BaseCourseVideoMapReduceTask
+):
+    """
+    Basic mapreduce task. Calculates total activity and unique users for each
+    video / user combo
+    """
+    def output(self):
+        output_name = u'user_video_summary_{name}/'.format(name=self.name)
+        return get_target_from_url(url_path_join(self.dest, output_name))
+
+
+class InsertToMysqlDirectTableBase(MysqlInsertTask):
+    """
+    Base class for directly inserting into MySQL table results
+    from a MapReduceJobTask. Subclasses should define their own
+    property attributes `table`, `columns` and `indexes`
+    """
+    def rows(self):
+        """
+        Re-formats the output of AnswerDistributionPerCourse to something insert_rows can understand
+        """
+        with self.input()['insert_source'].open('r') as fobj:
+            for line in fobj:
+                row = line.split('\t')
+                yield self.row_to_sql_tuple(row)
+
+    def row_to_sql_tuple(self, row):
+        """
+        Subclasses should implement this method to convert a csv row into
+        a tuple suitable for inserting into mysql
+        """
+        raise NotImplementedError
+
+
+# pylint: disable=abstract-method
+class InsertToMysqlCourseVideoSummaryTable(InsertToMysqlDirectTableBase):
+    """
+    Define course_video_summary table
+    """
+    @property
+    def table(self):
+        return "course_video_summary"
+
+    @property
+    def columns(self):
+        return [
+            ('course_id', 'VARCHAR(255) NOT NULL'),
+            ('video_id', 'VARCHAR(255) NOT NULL'),
+            ('date', 'DATETIME NOT NULL'),
+            ('total_activity', 'INT(11) NOT NULL'),
+            ('unique_users', 'INT(11) NOT NULL'),
+        ]
+
+    @property
+    def indexes(self):
+        return [
+            ('course_id',),
+            ('video_id',),
+            ('date',),
+        ]
+
+    def row_to_sql_tuple(self, row):
+        return [
+            row[0],
+            row[1],
+            datetime.strptime(row[2], DATE_FMT),
+            int(row[3]),
+            int(row[4]),
+        ]
+
+
+# pylint: disable=abstract-method
+class InsertToMysqlCourseVideoSeekTimesTable(InsertToMysqlDirectTableBase):
+    """
+    Define course_video_seek_times table.
+    """
+    @property
+    def table(self):
+        return "course_video_seek_times"
+
+    @property
+    def columns(self):
+        return [
+            ('course_id', 'VARCHAR(255) NOT NULL'),
+            ('video_id', 'VARCHAR(255) NOT NULL'),
+            ('date', 'DATETIME NOT NULL'),
+            ('seek_interval', 'INT(11) NOT NULL'),
+            ('num_seeks', 'INT(11) NOT NULL'),
+            ('num_users', 'INT(11) NOT NULL'),
+        ]
+
+    @property
+    def indexes(self):
+        return [
+            ('course_id',),
+            ('video_id',),
+            ('date',),
+        ]
+
+    def row_to_sql_tuple(self, row):
+        return [
+            row[0],
+            row[1],
+            datetime.strptime(row[2], DATE_FMT),
+            int(row[3]),
+            int(row[4]),
+            int(row[5]),
+        ]
+
+
+class InsertToMysqlUserVideoSummaryTable(InsertToMysqlDirectTableBase):
+    """
+    Define answer_distribution table.
+    """
+    @property
+    def table(self):
+        return "user_video_summary"
+
+    @property
+    def columns(self):
+        return [
+            ('course_id', 'VARCHAR(255) NOT NULL'),
+            ('username', 'VARCHAR(255) NOT NULL'),
+            ('date', 'DATETIME NOT NULL'),
+            ('total_activity', 'INT(11) NOT NULL'),
+            ('unique_videos_watched', 'INT(11) NOT NULL'),
+            ('total_time_spent', 'INT(11) NOT NULL'),
+        ]
+
+    @property
+    def indexes(self):
+        return [
+            ('course_id',),
+            ('username',),
+            ('date',),
+        ]
+
+    def row_to_sql_tuple(self, row):
+        return [
+            row[0],
+            row[1],
+            datetime.strptime(row[2], DATE_FMT),
+            int(row[3]),
+            int(row[4]),
+            int(row[5]),
+        ]
+
+
+class CourseVideoSummaryToMySQLTaskWorkflow(
+    InsertToMysqlCourseVideoSummaryTable,
+    CourseVideoDownstreamMixin,
+    MapReduceJobTaskMixin
+):
+    """
+    Task to launch a pipeline that takes as input a raw event log file, runs
+    the SQL summary task, and outputs to a MySQL database
+    """
+    @property
+    def insert_source_task(self):
+        """
+        Write to answer_distribution table from AnswerDistributionTSVTask.
+        """
+        return CourseVideoSummaryTask(
+            mapreduce_engine=self.mapreduce_engine,
+            lib_jar=self.lib_jar,
+            n_reduce_tasks=self.n_reduce_tasks,
+            src=self.src,
+            dest=self.dest,
+            include=self.include,
+            name=self.name,
+            manifest=self.manifest,
+        )
+
+
+class CourseVideoSeekTimesToMySQLTaskWorkflow(
+    InsertToMysqlCourseVideoSeekTimesTable,
+    CourseVideoDownstreamMixin,
+    MapReduceJobTaskMixin
+):
+    """
+    Task to launch a pipeline that takes as input a raw event log file, runs
+    the SQL summary task, and outputs to a MySQL database
+    """
+    @property
+    def insert_source_task(self):
+        """ Docstring """
+        return CourseVideoSeekTimesTask(
+            mapreduce_engine=self.mapreduce_engine,
+            lib_jar=self.lib_jar,
+            n_reduce_tasks=self.n_reduce_tasks,
+            src=self.src,
+            dest=self.dest,
+            include=self.include,
+            name=self.name,
+            manifest=self.manifest,
+        )
+
+
+class UserVideoSummaryToMySQLTaskWorkflow(
+    InsertToMysqlUserVideoSummaryTable,
+    CourseVideoDownstreamMixin,
+    MapReduceJobTaskMixin
+):
+    """
+    Task to launch a pipeline that takes as input a raw event log file, runs
+    the SQL summary task, and outputs to a MySQL database
+    """
+    @property
+    def insert_source_task(self):
+        """ Docstring """
+        return UserVideoSummaryTask(
+            mapreduce_engine=self.mapreduce_engine,
+            lib_jar=self.lib_jar,
+            n_reduce_tasks=self.n_reduce_tasks,
+            src=self.src,
+            dest=self.dest,
+            include=self.include,
+            name=self.name,
+            manifest=self.manifest,
+        )
+
+
+class CourseVideoWorkflow(
+    CourseVideoDownstreamMixin,
+    MysqlInsertTaskMixin,
+    MapReduceJobTaskMixin,
+    luigi.WrapperTask
+):
+    """
+    Calculates video summary, per-course, per-user, and seek-time
+    information
+    """
+    def requires(self):
+        kwargs = {
+            'mapreduce_engine': self.mapreduce_engine,
+            'lib_jar': self.lib_jar,
+            'n_reduce_tasks': self.n_reduce_tasks,
+            'name': self.name,
+            'src': self.src,
+            'dest': self.dest,
+            'include': self.include,
+            'manifest': self.manifest,
+            'database': self.database,
+            'credentials': self.credentials,
+            'insert_chunk_size': self.insert_chunk_size,
+        }
+
+        yield (
+            CourseVideoSummaryToMySQLTaskWorkflow(**kwargs),
+            CourseVideoSeekTimesToMySQLTaskWorkflow(**kwargs),
+            UserVideoSummaryToMySQLTaskWorkflow(**kwargs),
+        )

--- a/edx/analytics/tasks/course_video.py
+++ b/edx/analytics/tasks/course_video.py
@@ -14,7 +14,7 @@ import luigi.s3
 from edx.analytics.tasks.mapreduce import MapReduceJobTask, MapReduceJobTaskMixin
 from edx.analytics.tasks.pathutil import PathSetTask
 from edx.analytics.tasks.url import get_target_from_url, url_path_join
-from edx.analytics.tasks.mysql_load import MysqlInsertTask, MysqlInsertTaskMixin
+from edx.analytics.tasks.mysql_load import MysqlInsertTask
 import edx.analytics.tasks.util.eventlog as eventlog
 import edx.analytics.tasks.util.opaque_key_util as opaque_key_util
 
@@ -638,7 +638,6 @@ class UserVideoSummaryToMySQLTaskWorkflow(
 
 class CourseVideoWorkflow(
     CourseVideoDownstreamMixin,
-    MysqlInsertTaskMixin,
     MapReduceJobTaskMixin,
     luigi.WrapperTask
 ):

--- a/edx/analytics/tasks/tests/test_course_video.py
+++ b/edx/analytics/tasks/tests/test_course_video.py
@@ -1,0 +1,549 @@
+"""
+Tests for tasks that calculate course videos.
+
+"""
+import json
+import StringIO
+import math
+from operator import itemgetter
+from datetime import datetime
+
+from mock import Mock, patch
+
+from edx.analytics.tasks.course_video import (
+    CourseVideoEventMixin,
+    CourseVideoSummaryTask,
+    CourseVideoSeekTimesTask,
+    UserVideoSummaryTask,
+    CourseVideoWorkflow,
+    round_to_nearest,
+    round_datetime_to_nearest_day,
+    EVENT_ACTION_MAPPING,
+    SEEK_INTERVAL_IN_SEC,
+    DATE_FMT,
+)
+
+from edx.analytics.tasks.tests import unittest
+from edx.analytics.tasks.tests.config import with_luigi_config, OPTION_REMOVED
+from edx.analytics.tasks.tests.opaque_key_mixins import InitializeOpaqueKeysMixin
+
+
+VIDEO_MAX_LEN_IN_SEC = 300
+
+
+EVENT_TYPES = tuple(EVENT_ACTION_MAPPING.keys())
+
+
+class CourseVideoTestSetupMixin(object):
+    """ Base mixin class for testing course video tasks. """
+
+    # Task constructor
+    task = None
+
+    # Which event_type to use for every log creation task.
+    # If not set, uses default (play_video).
+    log_event_type = None
+
+    def setUp(self):
+        self.username = "test_user"
+        self.user_id = 24
+        self.course_id = "HumanitiesSciences/HB135/Fall2014"
+        self.org_id = "HumanitiesSciences"
+        self.session_id = "195ng4w5yq834o854"
+        self.video_id = "i4x-Engineering-CVX101-video-1938d1ec9c0b4eba97bc2f28dbbc9442"
+        self.timestamp = "2013-12-17T15:38:32.805444"
+        self.timestamp_datetime = datetime.strptime(self.timestamp, "%Y-%m-%dT%H:%M:%S.%f")
+        self.timestamp_datetime = datetime(2013, 12, 17, hour=15, minute=38, second=32, microsecond=805444)
+        try:
+            self.key = self.task.get_mapper_key(self._create_event_data_dict())
+        except:
+            self.key = None
+
+    def create_event_log_line(self, **kwargs):
+        """ Create an event log with test values, as a JSON string."""
+        return json.dumps(self._create_event_data_dict(**kwargs))
+
+    def _create_event_data_dict(self, **kwargs):
+        """ Returns event data dict with test values."""
+        default_event_type = self.log_event_type if self.log_event_type else EVENT_TYPES[0]
+        event_type = kwargs.get("event_type", default_event_type)
+        event_dict = {
+            "username": self.username,
+            "host": "test_host",
+            "event_source": "server",
+            "event_type": default_event_type,
+            "context": {
+                "course_id": kwargs.get('course_id', self.course_id),
+                "org_id": kwargs.get('context_org_id', self.org_id),
+                "path": "/event",
+                "user_id": kwargs.get('context_user_id', self.user_id),
+            },
+            "time": "{0}+00:00".format(self.timestamp),
+            "ip": "127.0.0.1",
+            "event": self._generate_event_for_video_event_type(event_type),
+            "agent": "blah, blah, blah",
+            "session": self.session_id,
+            "page": None
+        }
+        event_dict.update(**kwargs)
+        return event_dict
+
+    def _generate_event_for_video_event_type(self, event_type):
+        """ Generates event data for event log depending on video player action"""
+        if event_type == "seek_video":
+            old_time = VIDEO_MAX_LEN_IN_SEC / 2
+            new_time = VIDEO_MAX_LEN_IN_SEC
+            return {
+                "id": self.video_id,
+                "old_time": old_time,
+                "new_time": new_time,
+                "type": "onSlideSeek",
+                "code": "OzkqKknjuEQ",
+            }
+        else:
+            return {
+                "id": self.video_id,
+                "currentTime": 77,
+                "code": "LzRsgmV8c8c8",
+            }
+
+    def _get_reducer_output(self, lines):
+        """ Gets dict of keys / values representing reducer output for a given array of lines """
+        mapper_outputs = [tuple(self.task.mapper(line))[0] for line in lines]
+        unique_keys = set(map(itemgetter(0), mapper_outputs))
+        reducer_output = {}
+        for _key in unique_keys:
+            values = [output[1] for output in mapper_outputs if output[0] == _key]
+            reducer_key, output = tuple(self.task.reducer(_key, values))[0]
+            reducer_output[reducer_key] = output
+        return reducer_output
+
+
+class CommonCourseVideoTestsMixin(object):
+    """ Common class that holds a series of tests useful
+    for Course Video tasks. Implement as a mixin because
+    these tests rely on implementations of `get_mapper_key`
+    and `get_mapper_value` that are specific to the Task """
+
+    def test_parse_log_line(self):
+        """ Tests common parse log line for each task type.
+
+        Each task must implement its own version of `get_mapper_key`
+        and `get_mapper_value`, hence we put it here
+        """
+        line = self.create_event_log_line()
+        key, value = self.task.parse_log_line(line)
+
+        event_dict = self._create_event_data_dict()
+        self.assertEquals(key, self.key)
+        self.assertEquals(value, self.task.get_mapper_value(event_dict))
+
+    def test_parse_log_line_bad_input(self):
+        """ Tests bad input handling for parsing log lines
+        for each task type.
+
+        Each task must implement its own version of `get_mapper_key`
+        and `get_mapper_value`, hence we put it here
+        """
+        line = self.create_event_log_line(time="invalid timestamp")
+        self.assertIsNone(self.task.parse_log_line(line))
+
+    def assert_no_output_for(self, line):
+        """Assert that an input line generates no output."""
+        self.assertEquals(tuple(self.task.mapper(line)), ())
+
+    def test_malformed_log_entry(self):
+        line = "this is garbage"
+        self.assert_no_output_for(line)
+
+    def test_missing_username(self):
+        line = self.create_event_log_line(username=None)
+        self.assert_no_output_for(line)
+
+    def test_missing_event_type(self):
+        event_dict = self._create_event_data_dict()
+        event_dict["old_event_type"] = event_dict['event_type']
+        del event_dict["event_type"]
+        line = json.dumps(event_dict)
+        self.assert_no_output_for(line)
+
+    def test_bad_datetime(self):
+        line = self.create_event_log_line(time="this is a bogus time")
+        self.assert_no_output_for(line)
+
+    def test_bad_event_data(self):
+        line = self.create_event_log_line(event=["not an event"])
+        self.assert_no_output_for(line)
+
+    def test_missing_course_id(self):
+        line = self.create_event_log_line(context={})
+        self.assert_no_output_for(line)
+
+    def test_illegal_course_id(self):
+        line = self.create_event_log_line(course_id=";;;;bad/id/val")
+        self.assert_no_output_for(line)
+
+    def test_missing_video_id(self):
+        temp = self.video_id
+        self.video_id = None
+        line = self.create_event_log_line()
+        print line
+        self.video_id = temp
+        self.assert_no_output_for(line)
+
+    def test_missing_context(self):
+        line = self.create_event_log_line(context=None)
+        self.assert_no_output_for(line)
+
+
+class CourseVideoEventMixinTest(CourseVideoTestSetupMixin, unittest.TestCase):
+    """ Tests the base mixin class's mapper / reducer
+    functions. Tasks share these functions, so no need
+    to rerun common tests. """
+
+    def test_mapper(self):
+        """ Tests a fake mapper """
+
+        #--pylint: disable=W0612
+        with patch('edx.analytics.tasks.course_video.CourseVideoEventMixin.get_mapper_key') as get_mapper_key, \
+            patch('edx.analytics.tasks.course_video.CourseVideoEventMixin.get_mapper_value') as get_mapper_value:
+
+            expected_key = (self.course_id, self.video_id,)
+            expected_value = (self.timestamp,)
+
+            self.task = CourseVideoEventMixin()
+
+            get_mapper_key.return_value = expected_key
+            get_mapper_value.return_value = expected_value
+
+            line = self.create_event_log_line()
+            mapper_output = tuple(self.task.mapper(line))[0]
+            self.assertEquals(len(mapper_output), 2)
+            self.assertEquals(mapper_output[0], expected_key)
+            self.assertEquals(mapper_output[1], expected_value)
+
+
+class CourseVideoSummaryTaskTest(CourseVideoTestSetupMixin, CommonCourseVideoTestsMixin, unittest.TestCase):
+    """ Tests course video basic usage extraction from logs """
+
+    task = CourseVideoSummaryTask(
+        mapreduce_engine='local',
+        src=None,
+        dest=None,
+        name=None,
+        include=None)
+
+    log_event_type = 'play_video'
+
+    def test_reducer_single_event(self):
+        """ Tests reducer output with single event """
+        line = self.create_event_log_line()
+        reducer_output = self._get_reducer_output([line])
+
+        event_dict = self._create_event_data_dict()
+        mapper_key = self.task.get_mapper_key(event_dict)
+        value = reducer_output.get(mapper_key)
+        self.assertEqual(self.key, mapper_key)
+        self.assertIsNotNone(value)
+        self.assertEqual(value[0], 1)
+        self.assertEqual(value[1], 1)
+
+    def test_reducer_multi_user(self):
+        lines = [
+            self.create_event_log_line(),
+            self.create_event_log_line(username='johndoe111'),
+        ]
+        reducer_output = self._get_reducer_output(lines)
+
+        event_dict = self._create_event_data_dict()
+        mapper_key = self.task.get_mapper_key(event_dict)
+        value = reducer_output.get(mapper_key)
+        self.assertEqual(self.key, mapper_key)
+        self.assertIsNotNone(value)
+        self.assertEqual(value[0], 2)
+        self.assertEqual(value[1], 2)
+
+    def test_reducer_multi_events(self):
+        lines = [
+            self.create_event_log_line(),
+            self.create_event_log_line(),
+            self.create_event_log_line(),
+        ]
+        reducer_output = self._get_reducer_output(lines)
+
+        event_dict = self._create_event_data_dict()
+        mapper_key = self.task.get_mapper_key(event_dict)
+        value = reducer_output.get(mapper_key)
+        self.assertEqual(self.key, mapper_key)
+        self.assertIsNotNone(value)
+        self.assertEqual(value[0], 1)
+        self.assertEqual(value[1], 3)
+
+    def test_reducer_multi_course_events(self):
+        lines = [
+            self.create_event_log_line(),
+            self.create_event_log_line(course_id="Engineering/CS-224/Spring2015"),
+        ]
+        reducer_output = self._get_reducer_output(lines)
+
+        self.assertEquals(len(reducer_output), 2)
+
+        event_dict = self._create_event_data_dict()
+        mapper_key = self.task.get_mapper_key(event_dict)
+        value = reducer_output.get(mapper_key)
+        self.assertEqual(self.key, mapper_key)
+        self.assertIsNotNone(value)
+        self.assertEqual(value[0], 1)
+        self.assertEqual(value[1], 1)
+
+    def test_get_mapper_key(self):
+        event_dict = self._create_event_data_dict()
+        output_key = tuple(self.task.get_mapper_key(event_dict))
+        self.assertEqual(len(output_key), 3)
+
+        self.assertEqual(output_key[0], self.course_id)
+        self.assertEqual(output_key[1], self.video_id)
+        self.assertEqual(output_key[2], round_datetime_to_nearest_day(self.timestamp_datetime))
+
+    def test_get_mapper_value(self):
+        event_dict = self._create_event_data_dict()
+        mapper_output = tuple(self.task.get_mapper_value(event_dict))
+        self.assertEqual(len(mapper_output), 2)
+        self.assertEqual(mapper_output[0], self.username)
+        self.assertTrue(mapper_output[1] in EVENT_ACTION_MAPPING.values())
+
+
+class CourseVideoSeekTimesTaskTest(CourseVideoTestSetupMixin, CommonCourseVideoTestsMixin, unittest.TestCase):
+    """ Tests seek time extraction from logs """
+
+    task = CourseVideoSeekTimesTask(
+        mapreduce_engine='local',
+        src=None,
+        dest=None,
+        name=None,
+        include=None)
+
+    log_event_type = 'seek_video'
+
+    def create_seek_times_log(self, **kwargs):
+        """ Create a series of seek events for our video """
+        events = []
+        start = VIDEO_MAX_LEN_IN_SEC / 4
+        step_size = VIDEO_MAX_LEN_IN_SEC / 10
+        for i in range(5):
+            additional_attrs = {"event_type": "seek_video"}
+            additional_attrs.update(kwargs)
+            log_line = self._create_event_data_dict(**additional_attrs)
+            log_line.get('event').update({
+                'old_time': start + (i - 1) * step_size,
+                'new_time': start + i * step_size
+            })
+            events.append(json.dumps(log_line))
+        return events
+
+    def test_reducer_single_event(self):
+        """ Tests reducer output with single event """
+        line = self.create_event_log_line()
+        reducer_output = self._get_reducer_output([line])
+
+        event_dict = self._create_event_data_dict()
+        mapper_key = self.task.get_mapper_key(event_dict)
+        value = reducer_output.get(mapper_key)
+        self.assertEqual(self.key, mapper_key)
+        self.assertIsNotNone(value)
+        self.assertEqual(value[0], 1)
+        self.assertEqual(value[1], 1)
+
+    def test_reducer_multi_user(self):
+        lines = [
+            self.create_event_log_line(),
+            self.create_event_log_line(username='johndoe111'),
+        ]
+        reducer_output = self._get_reducer_output(lines)
+
+        event_dict = self._create_event_data_dict()
+        mapper_key = self.task.get_mapper_key(event_dict)
+        value = reducer_output.get(mapper_key)
+        self.assertEqual(self.key, mapper_key)
+        self.assertIsNotNone(value)
+        self.assertEqual(value[0], 2)
+        self.assertEqual(value[1], 2)
+
+    def test_reducer_multi_events(self):
+        lines = [
+            self.create_event_log_line(event_type='seek_video', context_old_time=200, context_new_time=100),
+            self.create_event_log_line(event_type='seek_video', context_old_time=300, context_new_time=500),
+            self.create_event_log_line(event_type='seek_video', context_old_time=50, context_new_time=100),
+        ]
+        reducer_output = self._get_reducer_output(lines)
+
+        event_dict = self._create_event_data_dict()
+        mapper_key = self.task.get_mapper_key(event_dict)
+        value = reducer_output.get(mapper_key)
+        self.assertEqual(self.key, mapper_key)
+        self.assertIsNotNone(value)
+        self.assertEquals(len(value), 2),
+        self.assertEquals(value[0], 3)
+        self.assertEquals(value[1], 1)
+
+    def test_reducer_multi_course_events(self):
+        lines = [
+            self.create_event_log_line(),
+            self.create_event_log_line(course_id="Engineering/CS-224/Spring2015"),
+        ]
+        reducer_output = self._get_reducer_output(lines)
+
+        self.assertEquals(len(reducer_output), 2)
+
+        event_dict = self._create_event_data_dict()
+        mapper_key = self.task.get_mapper_key(event_dict)
+        value = reducer_output.get(mapper_key)
+        self.assertEqual(self.key, mapper_key)
+        self.assertIsNotNone(value)
+        self.assertEqual(value[0], 1)
+        self.assertEqual(value[1], 1)
+
+    def test_get_mapper_key(self):
+        event_dict = self._create_event_data_dict()
+        output_key = self.task.get_mapper_key(event_dict)
+        self.assertEqual(len(output_key), 4)
+
+        self.assertEqual(output_key[0], self.course_id)
+        self.assertEqual(output_key[1], self.video_id)
+        self.assertEqual(output_key[2], round_datetime_to_nearest_day(self.timestamp_datetime))
+        self.assertEqual(output_key[3], round_to_nearest(VIDEO_MAX_LEN_IN_SEC, SEEK_INTERVAL_IN_SEC))
+
+    def test_get_mapper_value(self):
+        event_dict = self._create_event_data_dict()
+        mapper_output = self.task.get_mapper_value(event_dict)
+        self.assertEqual(len(mapper_output), 2)
+        self.assertEqual(mapper_output[0], self.username)
+        self.assertEqual(mapper_output[1], self.timestamp_datetime)
+
+
+class UserVideoSummaryTaskTest(CourseVideoTestSetupMixin, CommonCourseVideoTestsMixin, unittest.TestCase):
+    """ Tests user video summary from logs """
+
+    task = UserVideoSummaryTask(
+        mapreduce_engine='local',
+        src=None,
+        dest=None,
+        name=None,
+        include=None)
+
+    def test_reducer_single_event(self):
+        """ Tests reducer output with single event """
+        line = self.create_event_log_line()
+        reducer_output = self._get_reducer_output([line])
+
+        event_dict = self._create_event_data_dict()
+        mapper_key = self.task.get_mapper_key(event_dict)
+        value = reducer_output.get(mapper_key)
+        self.assertEqual(self.key, mapper_key)
+        self.assertIsNotNone(value)
+        self.assertEqual(len(value), 3)
+
+    def test_reducer_multi_user(self):
+        lines = [
+            self.create_event_log_line(),
+            self.create_event_log_line(username='johndoe111'),
+        ]
+        reducer_output = self._get_reducer_output(lines)
+
+        event_dict = self._create_event_data_dict()
+        mapper_key = self.task.get_mapper_key(event_dict)
+        value = reducer_output.get(mapper_key)
+        self.assertEqual(self.key, mapper_key)
+        self.assertIsNotNone(value)
+        self.assertEqual(len(value), 3)
+
+    def test_reducer_multi_events(self):
+        lines = [
+            self.create_event_log_line(event_type='play_video'),
+            self.create_event_log_line(event_type='seek_video'),
+            self.create_event_log_line(event_type='stop_video'),
+        ]
+        reducer_output = self._get_reducer_output(lines)
+
+        event_dict = self._create_event_data_dict()
+        mapper_key = self.task.get_mapper_key(event_dict)
+        value = reducer_output.get(mapper_key)
+        self.assertEqual(self.key, mapper_key)
+        self.assertIsNotNone(value)
+        self.assertEqual(len(value), 3)
+
+    def test_reducer_multi_course_events(self):
+        lines = [
+            self.create_event_log_line(),
+            self.create_event_log_line(course_id="Engineering/CS224/Spring2015"),
+        ]
+        reducer_output = self._get_reducer_output(lines)
+        self.assertEquals(len(reducer_output), 2)
+
+        event_dict = self._create_event_data_dict()
+        mapper_key = self.task.get_mapper_key(event_dict)
+        value = reducer_output.get(mapper_key)
+        self.assertEqual(self.key, mapper_key)
+        self.assertIsNotNone(value)
+        self.assertEqual(len(value), 3)
+
+    def test_get_mapper_key(self):
+        event_dict = self._create_event_data_dict()
+        output_key = self.task.get_mapper_key(event_dict)
+        self.assertEqual(len(output_key), 3)
+
+        self.assertEqual(output_key[0], self.course_id)
+        self.assertEqual(output_key[1], self.username)
+        self.assertEqual(output_key[2], round_datetime_to_nearest_day(self.timestamp_datetime))
+
+    def test_get_mapper_value(self):
+        event_dict = self._create_event_data_dict()
+        result = self.task.get_mapper_value(event_dict)
+        self.assertEqual(len(result), 4)
+        self.assertEqual(result[0], self.video_id)
+        self.assertTrue(result[1] in EVENT_ACTION_MAPPING.values())
+        self.assertEqual(result[2], self.session_id)
+        self.assertEqual(result[3], self.timestamp_datetime)
+
+
+class TestHelperFunctions(unittest.TestCase):
+    """
+    Test cases for helper functions
+    """
+
+    def test_round_to_nearest(self):
+        self.assertEqual(round_to_nearest(0, 60), 0)
+        self.assertEqual(round_to_nearest(30, 60), 0)
+        self.assertEqual(round_to_nearest(60, 60), 60)
+        self.assertEqual(round_to_nearest(70, 60), 60)
+        self.assertEqual(round_to_nearest(122, 60), 120)
+
+    def test_round_to_nearest_bad_input(self):
+        with self.assertRaises(ZeroDivisionError):
+            round_to_nearest(0, 0)
+
+        self.assertEquals(round_to_nearest(0, float("inf")), None)
+        self.assertEquals(round_to_nearest(float("inf"), float('inf')), None)
+        self.assertEquals(round_to_nearest(0, float("nan")), None)
+
+        with self.assertRaises(ZeroDivisionError):
+            round_to_nearest(float("nan"), 0)
+
+    EXPECTED_DATETIMES_TO_NEAREST_DAYS = (
+        (datetime(2015, 8, 3, hour=12, minute=12, second=30), datetime(2015, 8, 3)),
+        (datetime(2015, 7, 1, hour=23, minute=59, second=59), datetime(2015, 7, 1)),
+        (datetime(2015, 7, 2, hour=0,  minute=0,  second=1),  datetime(2015, 7, 2)),
+        (datetime(2015, 3, 29, hour=23,  minute=30,  second=13),  datetime(2015, 3, 29)),
+    )
+
+    def test_datetime_to_nearest_day(self):
+        for datetime_obj, datetime_rounded in self.EXPECTED_DATETIMES_TO_NEAREST_DAYS:
+            self.assertEquals(round_datetime_to_nearest_day(datetime_obj),
+                    datetime_rounded.strftime(DATE_FMT))
+
+    def test_datetime_to_nearest_day_bad_input(self):
+        self.assertIsNone(round_datetime_to_nearest_day(None))
+        self.assertIsNone(round_datetime_to_nearest_day("bad input string"))
+        self.assertIsNone(round_datetime_to_nearest_day(123))
+        self.assertIsNone(round_datetime_to_nearest_day({}))
+        self.assertIsNone(round_datetime_to_nearest_day([]))


### PR DESCRIPTION
Add course video analytics for analytics pipeline. Up for review. @dylanrhodes @dcadams

This commit adds a single task - CourseVideoWorkflowTask, that executes 3 tasks (CourseVideoSummaryTask, CourseVideoSeekTimesTask, and UserVideoSummaryTask) to pull analytics information from videos into the analytics mysql database.

This has been tested on logs from 2014 and 2015 from aws.

@dcadams during manual testing, we discussed a problem with the table user_video_summary in which the columns unique_videos_watched and total_activity were switched. This problem can be addressed by dropping and recreating tables on my VM.
